### PR TITLE
Add additionalProperties: false to UEI Layer 2 Configuration 

### DIFF
--- a/UEI/layer2/ev-charging_uei_1.1.0.yaml
+++ b/UEI/layer2/ev-charging_uei_1.1.0.yaml
@@ -17,6 +17,7 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
                 context:
                   allOf:
@@ -27,6 +28,7 @@ paths:
                             - search
                 message:
                   type: object
+                  additionalProperties: false
                   properties:
                     intent:
                       $ref: "#/components/schemas/Intent"
@@ -46,6 +48,7 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
                 context:
                   allOf:
@@ -58,6 +61,7 @@ paths:
                         - action
                 message:
                   type: object
+                  additionalProperties: false
                   properties:
                     order:
                       $ref: "#/components/schemas/Order"
@@ -79,6 +83,7 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
                 context:
                   allOf:
@@ -91,6 +96,7 @@ paths:
                         - action
                 message:
                   type: object
+                  additionalProperties: false
                   properties:
                     order:
                       $ref: "#/components/schemas/Order"
@@ -106,9 +112,11 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties: false
                 properties:
                   message:
                     type: object
+                    additionalProperties: false
                     properties:
                       ack:
                         allOf:
@@ -134,6 +142,7 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
                 context:
                   allOf:
@@ -146,6 +155,7 @@ paths:
                         - action
                 message:
                   type: object
+                  additionalProperties: false
                   properties:
                     order:
                       $ref: "#/components/schemas/Order"
@@ -167,6 +177,7 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
                 context:
                   allOf:
@@ -179,6 +190,7 @@ paths:
                         - action
                 message:
                   type: object
+                  additionalProperties: false
                   properties:
                     order_id:
                       $ref: "#/components/schemas/Order/properties/id"
@@ -200,6 +212,7 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
                 context:
                   allOf:
@@ -212,6 +225,7 @@ paths:
                         - action
                 message:
                   type: object
+                  additionalProperties: false
                   properties:
                     order_id:
                       $ref: "#/components/schemas/Order/properties/id"
@@ -236,6 +250,7 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
                 context:
                   allOf:
@@ -248,6 +263,7 @@ paths:
                         - action
                 message:
                   type: object
+                  additionalProperties: false
                   properties:
                     order_id:
                       $ref: "#/components/schemas/Order/properties/id"
@@ -273,6 +289,7 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
                 context:
                   allOf:
@@ -285,6 +302,7 @@ paths:
                         - action
                 message:
                   type: object
+                  additionalProperties: false
                   properties:
                     update_target:
                       description: 'Comma separated values of order objects being updated. For example: ```"update_target":"item,billing,fulfillment"```'
@@ -312,6 +330,7 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
                 context:
                   allOf:
@@ -324,6 +343,7 @@ paths:
                         - action
                 message:
                   type: object
+                  additionalProperties: false
                   properties:
                     ratings:
                       type: array
@@ -345,6 +365,7 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
                 context:
                   allOf:
@@ -357,6 +378,7 @@ paths:
                         - action
                 message:
                   type: object
+                  additionalProperties: false
                   properties:
                     support:
                       $ref: "#/components/schemas/Support"
@@ -377,6 +399,7 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
                 context:
                   allOf:
@@ -389,6 +412,7 @@ paths:
                         - action
                 message:
                   type: object
+                  additionalProperties: false
                   properties:
                     catalog:
                       $ref: "#/components/schemas/Catalog"
@@ -411,6 +435,7 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
                 context:
                   allOf:
@@ -423,6 +448,7 @@ paths:
                         - action
                 message:
                   type: object
+                  additionalProperties: false
                   properties:
                     order:
                       $ref: "#/components/schemas/Order"
@@ -443,6 +469,7 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
                 context:
                   allOf:
@@ -455,6 +482,7 @@ paths:
                         - action
                 message:
                   type: object
+                  additionalProperties: false
                   properties:
                     order:
                       $ref: "#/components/schemas/Order"
@@ -477,6 +505,7 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
                 context:
                   allOf:
@@ -489,6 +518,7 @@ paths:
                         - action
                 message:
                   type: object
+                  additionalProperties: false
                   properties:
                     order:
                       $ref: "#/components/schemas/Order"
@@ -511,6 +541,7 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
                 context:
                   allOf:
@@ -523,6 +554,7 @@ paths:
                         - action
                 message:
                   type: object
+                  additionalProperties: false
                   properties:
                     tracking:
                       $ref: "#/components/schemas/Tracking"
@@ -545,6 +577,7 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
                 context:
                   allOf:
@@ -557,6 +590,7 @@ paths:
                         - action
                 message:
                   type: object
+                  additionalProperties: false
                   properties:
                     order:
                       $ref: "#/components/schemas/Order"
@@ -579,6 +613,7 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
                 context:
                   allOf:
@@ -591,6 +626,7 @@ paths:
                         - action
                 message:
                   type: object
+                  additionalProperties: false
                   properties:
                     order:
                       $ref: "#/components/schemas/Order"
@@ -613,6 +649,7 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
                 context:
                   allOf:
@@ -625,6 +662,7 @@ paths:
                         - action
                 message:
                   type: object
+                  additionalProperties: false
                   properties:
                     order:
                       $ref: "#/components/schemas/Order"
@@ -647,6 +685,7 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
                 context:
                   allOf:
@@ -659,6 +698,7 @@ paths:
                         - action
                 message:
                   type: object
+                  additionalProperties: false
                   properties:
                     feedback_form:
                       description: A feedback form to allow the user to provide additional information on the rating provided
@@ -682,6 +722,7 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
                 context:
                   allOf:
@@ -694,6 +735,7 @@ paths:
                         - action
                 message:
                   type: object
+                  additionalProperties: false
                   properties:
                     support:
                       $ref: "#/components/schemas/Support"
@@ -715,6 +757,7 @@ components:
     Ack:
       description: "Describes the acknowledgement sent in response to an API call. If the implementation uses HTTP/S, then Ack must be returned in the same session. Every API call to a BPP must be responded to with an Ack whether the BPP intends to respond with a callback or not. This has one property called `status` that indicates the status of the Acknowledgement."
       type: object
+      additionalProperties: false
       properties:
         status:
           type: string
@@ -730,6 +773,7 @@ components:
     AddOn:
       description: Describes an additional item offered as a value-addition to a product or service. This does not exist independently in a catalog and is always associated with an item.
       type: object
+      additionalProperties: false
       properties:
         id:
           description: Provider-defined ID of the add-on
@@ -755,6 +799,7 @@ components:
     Authorization:
       description: "Describes an authorization mechanism used to start or end the fulfillment of an order. For example, in the mobility sector, the driver may require a one-time password to initiate the ride. In the healthcare sector, a patient may need to provide a password to open a video conference link during a teleconsultation."
       type: object
+      additionalProperties: false
       properties:
         type:
           description: Type of authorization mechanism used. The allowed values for this field can be published as part of the network policy.
@@ -776,6 +821,7 @@ components:
     Billing:
       description: "Describes the billing details of an entity.<br>This has properties like name,organization,address,email,phone,time,tax_number, created_at,updated_at"
       type: object
+      additionalProperties: false
       properties:
         name:
           description: Name of the billable entity
@@ -813,6 +859,7 @@ components:
     Cancellation:
       description: Describes a cancellation event
       type: object
+      additionalProperties: false
       properties:
         time:
           description: Date-time when the order was cancelled by the buyer
@@ -834,6 +881,7 @@ components:
     CancellationTerm:
       description: Describes the cancellation terms of an item or an order. This can be referenced at an item or order level. Item-level cancellation terms can override the terms at the order level.
       type: object
+      additionalProperties: false
       properties:
         fulfillment_state:
           description: The state of fulfillment during which this term is applicable.
@@ -855,6 +903,7 @@ components:
     Catalog:
       description: "Describes the products or services offered by a BPP. This is typically sent as the response to a search intent from a BAP. The payment terms, offers and terms of fulfillment supported by the BPP can also be included here. The BPP can show hierarchical nature of products/services in its catalog using the parent_category_id in categories. The BPP can also send a ttl (time to live) in the context which is the duration for which a BAP can cache the catalog and use the cached catalog.  <br>This has properties like bbp/descriptor,bbp/categories,bbp/fulfillments,bbp/payments,bbp/offers,bbp/providers and exp<br>This is used in the following situations.<br><ul><li>This is typically used in the discovery stage when the BPP sends the details of the products and services it offers as response to a search intent from the BAP. </li></ul>"
       type: object
+      additionalProperties: false
       properties:
         descriptor:
           $ref: "#/components/schemas/Descriptor"
@@ -887,6 +936,7 @@ components:
     Category:
       description: A label under which a collection of items can be grouped.
       type: object
+      additionalProperties: false
       properties:
         id:
           description: ID of the category
@@ -906,6 +956,7 @@ components:
     Circle:
       description: Describes a circular region of a specified radius centered at a specified GPS coordinate.
       type: object
+      additionalProperties: false
       properties:
         gps:
           $ref: "#/components/schemas/Gps"
@@ -914,6 +965,7 @@ components:
     City:
       description: Describes a city
       type: object
+      additionalProperties: false
       properties:
         name:
           description: Name of the city
@@ -924,6 +976,7 @@ components:
     Contact:
       description: Describes the contact information of an entity
       type: object
+      additionalProperties: false
       properties:
         phone:
           type: string
@@ -931,10 +984,12 @@ components:
           type: string
         jcard:
           type: object
+          additionalProperties: false
           description: A Jcard object as per draft-ietf-jcardcal-jcard-03 specification
     Context:
       description: "Every API call in beckn protocol has a context. It provides a high-level overview to the receiver about the nature of the intended transaction. Typically, it is the BAP that sets the transaction context based on the consumer's location and action on their UI. But sometimes, during unsolicited callbacks, the BPP also sets the transaction context but it is usually the same as the context of a previous full-cycle, request-callback interaction between the BAP and the BPP. The context object contains four types of fields. <ol><li>Demographic information about the transaction using fields like `domain`, `country`, and `region`.</li><li>Addressing details like the sending and receiving platform's ID and API URL.</li><li>Interoperability information like the protocol version that implemented by the sender and,</li><li>Transaction details like the method being called at the receiver's endpoint, the transaction_id that represents an end-to-end user session at the BAP, a message ID to pair requests with callbacks, a timestamp to capture sending times, a ttl to specifiy the validity of the request, and a key to encrypt information if necessary.</li></ol> This object must be passed in every interaction between a BAP and a BPP. In HTTP/S implementations, it is not necessary to send the context during the synchronous response. However, in asynchronous protocols, the context must be sent during all interactions,"
       type: object
+      additionalProperties: false
       properties:
         domain:
           description: Domain code that is relevant to this transaction context
@@ -990,6 +1045,7 @@ components:
     Country:
       description: Describes a country
       type: object
+      additionalProperties: false
       properties:
         name:
           type: string
@@ -1000,6 +1056,7 @@ components:
     Credential:
       description: Describes a credential of an entity - Person or Organization
       type: object
+      additionalProperties: false
       properties:
         id:
           type: string
@@ -1013,6 +1070,7 @@ components:
     Customer:
       description: Describes a customer buying/availing a product or a service
       type: object
+      additionalProperties: false
       properties:
         person:
           $ref: "#/components/schemas/Person"
@@ -1025,6 +1083,7 @@ components:
     Descriptor:
       description: Physical description of something.
       type: object
+      additionalProperties: false
       properties:
         name:
           type: string
@@ -1036,6 +1095,7 @@ components:
           type: string
         additional_desc:
           type: object
+          additionalProperties: false
           properties:
             url:
               type: string
@@ -1056,6 +1116,7 @@ components:
     Domain:
       description: "Described the industry sector or sub-sector. The network policy should contain codes for all the industry sectors supported by the network. Domains can be created in varying levels of granularity. The granularity of a domain can be decided by the participants of the network. Too broad domains will result in irrelevant search broadcast calls to BPPs that don't have services supporting the domain. Too narrow domains will result in a large number of registry entries for each BPP. It is recommended that network facilitators actively collaborate with various working groups and network participants to carefully choose domain codes keeping in mind relevance, performance, and opportunity cost. It is recommended that networks choose broad domains like mobility, logistics, healthcare etc, and progressively granularize them as and when the number of network participants for each domain grows large."
       type: object
+      additionalProperties: false
       properties:
         name:
           description: Name of the domain
@@ -1072,6 +1133,7 @@ components:
     Error:
       description: "Describes an error object that is returned by a BAP, BPP or BG as a response or callback to an action by another network participant. This object is sent when any request received by a network participant is unacceptable. This object can be sent either during Ack or with the callback."
       type: object
+      additionalProperties: false
       properties:
         code:
           type: string
@@ -1085,6 +1147,7 @@ components:
     Fee:
       description: A fee applied on a particular entity
       type: object
+      additionalProperties: false
       properties:
         percentage:
           description: Percentage of a value
@@ -1097,6 +1160,7 @@ components:
     Form:
       description: Describes a form
       type: object
+      additionalProperties: false
       properties:
         url:
           description: "The URL from where the form can be fetched. The content fetched from the url must be processed as per the mime_type specified in this object. Once fetched, the rendering platform can choosed to render the form as-is as an embeddable element; or process it further to blend with the theme of the application. In case the interface is non-visual, the the render can process the form data and reproduce it as per the standard specified in the form."
@@ -1119,6 +1183,7 @@ components:
     Fulfillment:
       description: Describes how a an order will be rendered/fulfilled to the end-customer
       type: object
+      additionalProperties: false
       properties:
         id:
           description: Unique reference ID to the fulfillment of an order
@@ -1168,6 +1233,7 @@ components:
     FulfillmentState:
       description: Describes the state of fulfillment
       type: object
+      additionalProperties: false
       properties:
         descriptor:
           $ref: "#/components/schemas/Descriptor"
@@ -1184,6 +1250,7 @@ components:
     Image:
       description: Describes an image
       type: object
+      additionalProperties: false
       properties:
         url:
           description: URL to the image. This can be a data url or an remote url
@@ -1208,6 +1275,7 @@ components:
     Intent:
       description: "The intent to buy or avail a product or a service. The BAP can declare the intent of the consumer containing <ul><li>What they want (A product, service, offer)</li><li>Who they want (A seller, service provider, agent etc)</li><li>Where they want it and where they want it from</li><li>When they want it (start and end time of fulfillment</li><li>How they want to pay for it</li></ul><br>This has properties like descriptor,provider,fulfillment,payment,category,offer,item,tags<br>This is typically used by the BAP to send the purpose of the user's search to the BPP. This will be used by the BPP to find products or services it offers that may match the user's intent.<br>For example, in Mobility, the mobility consumer declares a mobility intent. In this case, the mobility consumer declares information that describes various aspects of their journey like,<ul><li>Where would they like to begin their journey (intent.fulfillment.start.location)</li><li>Where would they like to end their journey (intent.fulfillment.end.location)</li><li>When would they like to begin their journey (intent.fulfillment.start.time)</li><li>When would they like to end their journey (intent.fulfillment.end.time)</li><li>Who is the transport service provider they would like to avail services from (intent.provider)</li><li>Who is traveling (This is not recommended in public networks) (intent.fulfillment.customer)</li><li>What kind of fare product would they like to purchase (intent.item)</li><li>What add-on services would they like to avail</li><li>What offers would they like to apply on their booking (intent.offer)</li><li>What category of services would they like to avail (intent.category)</li><li>What additional luggage are they carrying</li><li>How would they like to pay for their journey (intent.payment)</li></ul><br>For example, in health domain, a consumer declares the intent for a lab booking the describes various aspects of their booking like,<ul><li>Where would they like to get their scan/test done (intent.fulfillment.start.location)</li><li>When would they like to get their scan/test done (intent.fulfillment.start.time)</li><li>When would they like to get the results of their test/scan (intent.fulfillment.end.time)</li><li>Who is the service provider they would like to avail services from (intent.provider)</li><li>Who is getting the test/scan (intent.fulfillment.customer)</li><li>What kind of test/scan would they like to purchase (intent.item)</li><li>What category of services would they like to avail (intent.category)</li><li>How would they like to pay for their journey (intent.payment)</li></ul>"
       type: object
+      additionalProperties: false
       properties:
         descriptor:
           description: "A raw description of the search intent. Free text search strings, raw audio, etc can be sent in this object."
@@ -1244,10 +1312,12 @@ components:
     ItemQuantity:
       description: Describes the count or amount of an item
       type: object
+      additionalProperties: false
       properties:
         allocated:
           description: This represents the exact quantity allocated for purchase of the item.
           type: object
+          additionalProperties: false
           properties:
             count:
               type: integer
@@ -1257,6 +1327,7 @@ components:
         available:
           description: This represents the exact quantity available for purchase of the item. The buyer can only purchase multiples of this
           type: object
+          additionalProperties: false
           properties:
             count:
               type: integer
@@ -1266,6 +1337,7 @@ components:
         maximum:
           description: This represents the maximum quantity allowed for purchase of the item
           type: object
+          additionalProperties: false
           properties:
             count:
               type: integer
@@ -1275,6 +1347,7 @@ components:
         minimum:
           description: This represents the minimum quantity allowed for purchase of the item
           type: object
+          additionalProperties: false
           properties:
             count:
               type: integer
@@ -1284,6 +1357,7 @@ components:
         selected:
           description: This represents the quantity selected for purchase of the item
           type: object
+          additionalProperties: false
           properties:
             count:
               type: integer
@@ -1293,6 +1367,7 @@ components:
         unitized:
           description: This represents the quantity available in a single unit of the item
           type: object
+          additionalProperties: false
           properties:
             count:
               type: integer
@@ -1303,6 +1378,7 @@ components:
     Item:
       description: "Describes a product or a service offered to the end consumer by the provider. In the mobility sector, it can represent a fare product like one way journey. In the logistics sector, it can represent the delivery service offering. In the retail domain it can represent a product like a grocery item."
       type: object
+      additionalProperties: false
       properties:
         id:
           description: ID of the item.
@@ -1370,6 +1446,7 @@ components:
           items:
             description: Refund term of an item or an order
             type: object
+            additionalProperties: false
             properties:
               fulfillment_state:
                 description: The state of fulfillment during which this term is applicable.
@@ -1428,6 +1505,7 @@ components:
     Location:
       description: The physical location of something
       type: object
+      additionalProperties: false
       properties:
         id:
           type: string
@@ -1477,6 +1555,7 @@ components:
     MediaFile:
       description: This object contains a url to a media file.
       type: object
+      additionalProperties: false
       properties:
         mimetype:
           description: "indicates the nature and format of the document, file, or assortment of bytes. MIME types are defined and standardized in IETF's RFC 6838"
@@ -1494,6 +1573,7 @@ components:
     Offer:
       description: An offer associated with a catalog. This is typically used to promote a particular product and enable more purchases.
       type: object
+      additionalProperties: false
       properties:
         id:
           type: string
@@ -1520,6 +1600,7 @@ components:
     Option:
       description: Describes a selectable option
       type: object
+      additionalProperties: false
       properties:
         id:
           type: string
@@ -1528,6 +1609,7 @@ components:
     Order:
       description: Describes a legal purchase order. It contains the complete details of the legal contract created between the buyer and the seller.
       type: object
+      additionalProperties: false
       properties:
         id:
           type: string
@@ -1632,6 +1714,7 @@ components:
     Organization:
       description: An organization. Usually a recognized business entity.
       type: object
+      additionalProperties: false
       properties:
         descriptor:
           $ref: "#/components/schemas/Descriptor"
@@ -1652,6 +1735,7 @@ components:
     Payment:
       description: "Describes the terms of settlement between the BAP and the BPP for a single transaction. When instantiated, this object contains <ol><li>the amount that has to be settled,</li><li>The payment destination destination details</li><li>When the settlement should happen, and</li><li>A transaction reference ID</li></ol>. During a transaction, the BPP reserves the right to decide the terms of payment. However, the BAP can send its terms to the BPP first. If the BPP does not agree to those terms, it must overwrite the terms and return them to the BAP. If overridden, the BAP must either agree to the terms sent by the BPP in order to preserve the provider's autonomy, or abort the transaction. In case of such disagreements, the BAP and the BPP can perform offline negotiations on the payment terms. Once an agreement is reached, the BAP and BPP can resume transactions."
       type: object
+      additionalProperties: false
       properties:
         id:
           description: ID of the payment term that can be referred at an item or an order level in a catalog
@@ -1664,6 +1748,7 @@ components:
           format: uri
         params:
           type: object
+          additionalProperties: false
           properties:
             transaction_id:
               type: string
@@ -1705,6 +1790,7 @@ components:
     Person:
       description: Describes a person as any individual
       type: object
+      additionalProperties: false
       properties:
         id:
           type: string
@@ -1738,6 +1824,7 @@ components:
           items:
             description: Describes a language known to the person.
             type: object
+            additionalProperties: false
             properties:
               code:
                 type: string
@@ -1748,6 +1835,7 @@ components:
           items:
             description: Describes a skill of the person.
             type: object
+            additionalProperties: false
             properties:
               code:
                 type: string
@@ -1760,6 +1848,7 @@ components:
     Price:
       description: Describes the price of a product or service
       type: object
+      additionalProperties: false
       properties:
         currency:
           type: string
@@ -1780,6 +1869,7 @@ components:
     Provider:
       description: Describes the catalog of a business.
       type: object
+      additionalProperties: false
       properties:
         id:
           type: string
@@ -1835,6 +1925,7 @@ components:
     Quotation:
       description: "Describes a quote. It is the estimated price of products or services from the BPP.<br>This has properties like price, breakup, ttl"
       type: object
+      additionalProperties: false
       properties:
         id:
           description: ID of the quote.
@@ -1849,6 +1940,7 @@ components:
           type: array
           items:
             type: object
+            additionalProperties: false
             properties:
               item:
                 $ref: "#/components/schemas/Item"
@@ -1861,6 +1953,7 @@ components:
     Rating:
       description: Describes the rating of an entity
       type: object
+      additionalProperties: false
       properties:
         rating_category:
           description: Category of the entity being rated
@@ -1881,6 +1974,7 @@ components:
     Region:
       description: Describes an arbitrary region of space. The network policy should contain a published list of supported regions by the network.
       type: object
+      additionalProperties: false
       properties:
         dimensions:
           description: "The number of dimensions that are used to describe any point inside that region. The most common dimensionality of a region is 2, that represents an area on a map. There are regions on the map that can be approximated to one-dimensional regions like roads, railway lines, or shipping lines. 3 dimensional regions are rarer, but are gaining popularity as flying drones are being adopted for various fulfillment services."
@@ -1907,6 +2001,7 @@ components:
     ReplacementTerm:
       description: The replacement policy of an item or an order
       type: object
+      additionalProperties: false
       properties:
         fulfillment_state:
           description: The state of fulfillment during which this term is applicable.
@@ -1921,6 +2016,7 @@ components:
     ReturnTerm:
       description: Describes the return policy of an item or an order
       type: object
+      additionalProperties: false
       properties:
         fulfillment_state:
           description: The state of fulfillment during which this term IETF''s applicable.
@@ -1946,6 +2042,7 @@ components:
     Scalar:
       description: Describes a scalar
       type: object
+      additionalProperties: false
       properties:
         type:
           type: string
@@ -1960,6 +2057,7 @@ components:
           $ref: "#/components/schemas/DecimalValue"
         range:
           type: object
+          additionalProperties: false
           properties:
             min:
               $ref: "#/components/schemas/DecimalValue"
@@ -1970,6 +2068,7 @@ components:
     Schedule:
       description: "Describes schedule as a repeating time period used to describe a regularly recurring event. At a minimum a schedule will specify frequency which describes the interval between occurrences of the event. Additional information can be provided to specify the schedule more precisely. This includes identifying the timestamps(s) of when the event will take place. Schedules may also have holidays to exclude a specific day from the schedule.<br>This has properties like frequency, holidays, times"
       type: object
+      additionalProperties: false
       properties:
         frequency:
           $ref: "#/components/schemas/Duration"
@@ -1986,6 +2085,7 @@ components:
     State:
       description: A bounded geopolitical region of governance inside a country.
       type: object
+      additionalProperties: false
       properties:
         name:
           type: string
@@ -1996,6 +2096,7 @@ components:
     Stop:
       description: A logical point in space and time during the fulfillment of an order.
       type: object
+      additionalProperties: false
       properties:
         id:
           type: string
@@ -2029,6 +2130,7 @@ components:
     Support:
       description: Details of customer support
       type: object
+      additionalProperties: false
       properties:
         ref_id:
           type: string
@@ -2045,6 +2147,7 @@ components:
     Tag:
       description: "Describes a tag. This is used to contain extended metadata. This object can be added as a property to any schema to describe extended attributes. For BAPs, tags can be sent during search to optimize and filter search results. BPPs can use tags to index their catalog to allow better search functionality. Tags are sent by the BPP as part of the catalog response in the `on_search` callback. Tags are also meant for display purposes. Upon receiving a tag, BAPs are meant to render them as name-value pairs. This is particularly useful when rendering tabular information about a product or service."
       type: object
+      additionalProperties: false
       properties:
         descriptor:
           description: "Description of the Tag, can be used to store detailed information."
@@ -2059,6 +2162,7 @@ components:
     TagGroup:
       description: "A collection of tag objects with group level attributes. For detailed documentation on the Tags and Tag Groups schema go to https://github.com/beckn/protocol-specifications/discussions/316"
       type: object
+      additionalProperties: false
       properties:
         display:
           description: "Indicates the display properties of the tag group. If display is set to false, then the group will not be displayed. If it is set to true, it should be displayed. However, group-level display properties can be overriden by individual tag-level display property. As this schema is purely for catalog display purposes, it is not recommended to send this value during search."
@@ -2076,6 +2180,7 @@ components:
     Time:
       description: "Describes time in its various forms. It can be a single point in time; duration; or a structured timetable of operations<br>This has properties like label, time stamp,duration,range, days, schedule"
       type: object
+      additionalProperties: false
       properties:
         label:
           type: string
@@ -2086,6 +2191,7 @@ components:
           $ref: "#/components/schemas/Duration"
         range:
           type: object
+          additionalProperties: false
           properties:
             start:
               type: string
@@ -2101,6 +2207,7 @@ components:
     Tracking:
       description: Contains tracking information that can be used by the BAP to track the fulfillment of an order in real-time. which is useful for knowing the location of time sensitive deliveries.
       type: object
+      additionalProperties: false
       properties:
         id:
           description: A unique tracking reference number
@@ -2122,6 +2229,7 @@ components:
     Vehicle:
       description: "Describes a vehicle is a device that is designed or used to transport people or cargo over land, water, air, or through space.<br>This has properties like category, capacity, make, model, size,variant,color,energy_type,registration"
       type: object
+      additionalProperties: false
       properties:
         category:
           type: string
@@ -2154,6 +2262,7 @@ components:
     XInput:
       description: "Contains any additional or extended inputs required to confirm an order. This is typically a Form Input. Sometimes, selection of catalog elements is not enough for the BPP to confirm an order. For example, to confirm a flight ticket, the airline requires details of the passengers along with information on baggage, identity, in addition to the class of ticket. Similarly, a logistics company may require details on the nature of shipment in order to confirm the shipping. A recruiting firm may require additional details on the applicant in order to confirm a job application. For all such purposes, the BPP can choose to send this object attached to any object in the catalog that is required to be sent while placing the order. This object can typically be sent at an item level or at the order level. The item level XInput will override the Order level XInput as it indicates a special requirement of information for that particular item. Hence the BAP must render a separate form for the Item and another form at the Order level before confirmation."
       type: object
+      additionalProperties: false
       properties:
         form:
           $ref: "#/components/schemas/Form"


### PR DESCRIPTION
### Description:
This PR updates the UEI Layer 2 Configuration OpenAPI YAML document by setting additionalProperties: false in each object schema. This change is intended to enforce strict validation of the API schema, disallowing properties not explicitly defined in the schema.

### Changes Made:
Added additionalProperties: false to all object schemas within the UEI Layer 2 Configuration OpenAPI YAML file.
Ensured the document aligns with OpenAPI standards to prevent unexpected properties from being accepted in API requests and responses.
### Rationale:
Setting additionalProperties: false improves API reliability and data integrity by ensuring clients adhere strictly to the specified schema. This change prevents accidental inclusion of unintended fields, reducing potential data inconsistencies and making the API easier to maintain.

### Impact:
Validation: Requests and responses with properties not defined in the schema will now be rejected.
Compatibility: Existing clients sending extra properties may need adjustments to conform to the stricter schema validation.
### Testing:
Verified that the OpenAPI document is valid and compatible with OpenAPI tools.
Tested the schema validation in the application to ensure no unexpected properties are accepted.
### Additional Notes:
This update is backward-incompatible with clients that currently rely on unspecified properties.